### PR TITLE
feat: add Turborepo for monorepo build orchestration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,19 +50,11 @@ jobs:
         with:
           dict-cache: true
 
-      - name: Build libraries
+      - name: Build
         run: npm run build:fast
 
       - name: Generate docs
         run: npm run docs
-
-      # Run builds in parallel - website uses build:fast (skips tsc prebuild, done in lint)
-      - name: Build other packages
-        run: |
-          npm run build -w @ingglish/cors-proxy &
-          npm run build -w @ingglish/extension &
-          npm run build:fast -w @ingglish/website &
-          wait
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v6

--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,6 @@ test-results/
 # Lint caches
 .eslintcache
 
+# Turbo
+.turbo
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "stylelint": "^17.3.0",
         "stylelint-config-standard": "^40.0.0",
         "tsup": "^8.4.0",
+        "turbo": "^2.8.10",
         "typedoc": "^0.28.15",
         "typedoc-plugin-markdown": "^4.9.0",
         "typescript": "^5.8.3",
@@ -9217,6 +9218,108 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/turbo": {
+      "version": "2.8.10",
+      "resolved": "https://registry.npmjs.org/turbo/-/turbo-2.8.10.tgz",
+      "integrity": "sha512-OxbzDES66+x7nnKGg2MwBA1ypVsZoDTLHpeaP4giyiHSixbsiTaMyeJqbEyvBdp5Cm28fc+8GG6RdQtic0ijwQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "turbo": "bin/turbo"
+      },
+      "optionalDependencies": {
+        "turbo-darwin-64": "2.8.10",
+        "turbo-darwin-arm64": "2.8.10",
+        "turbo-linux-64": "2.8.10",
+        "turbo-linux-arm64": "2.8.10",
+        "turbo-windows-64": "2.8.10",
+        "turbo-windows-arm64": "2.8.10"
+      }
+    },
+    "node_modules/turbo-darwin-64": {
+      "version": "2.8.10",
+      "resolved": "https://registry.npmjs.org/turbo-darwin-64/-/turbo-darwin-64-2.8.10.tgz",
+      "integrity": "sha512-A03fXh+B7S8mL3PbdhTd+0UsaGrhfyPkODvzBDpKRY7bbeac4MDFpJ7I+Slf2oSkCEeSvHKR7Z4U71uKRUfX7g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/turbo-darwin-arm64": {
+      "version": "2.8.10",
+      "resolved": "https://registry.npmjs.org/turbo-darwin-arm64/-/turbo-darwin-arm64-2.8.10.tgz",
+      "integrity": "sha512-sidzowgWL3s5xCHLeqwC9M3s9M0i16W1nuQF3Mc7fPHpZ+YPohvcbVFBB2uoRRHYZg6yBnwD4gyUHKTeXfwtXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/turbo-linux-64": {
+      "version": "2.8.10",
+      "resolved": "https://registry.npmjs.org/turbo-linux-64/-/turbo-linux-64-2.8.10.tgz",
+      "integrity": "sha512-YK9vcpL3TVtqonB021XwgaQhY9hJJbKKUhLv16osxV0HkcQASQWUqR56yMge7puh6nxU67rQlTq1b7ksR1T3KA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/turbo-linux-arm64": {
+      "version": "2.8.10",
+      "resolved": "https://registry.npmjs.org/turbo-linux-arm64/-/turbo-linux-arm64-2.8.10.tgz",
+      "integrity": "sha512-3+j2tL0sG95iBJTm+6J8/45JsETQABPqtFyYjVjBbi6eVGdtNTiBmHNKrbvXRlQ3ZbUG75bKLaSSDHSEEN+btQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/turbo-windows-64": {
+      "version": "2.8.10",
+      "resolved": "https://registry.npmjs.org/turbo-windows-64/-/turbo-windows-64-2.8.10.tgz",
+      "integrity": "sha512-hdeF5qmVY/NFgiucf8FW0CWJWtyT2QPm5mIsX0W1DXAVzqKVXGq+Zf+dg4EUngAFKjDzoBeN6ec2Fhajwfztkw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/turbo-windows-arm64": {
+      "version": "2.8.10",
+      "resolved": "https://registry.npmjs.org/turbo-windows-arm64/-/turbo-windows-arm64-2.8.10.tgz",
+      "integrity": "sha512-QGdr/Q8LWmj+ITMkSvfiz2glf0d7JG0oXVzGL3jxkGqiBI1zXFj20oqVY0qWi+112LO9SVrYdpHS0E/oGFrMbQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -4,15 +4,15 @@
   "description": "Phonetic English spelling translator",
   "private": true,
   "type": "module",
+  "packageManager": "npm@10.9.4",
   "workspaces": [
     "packages/*"
   ],
   "scripts": {
     "docs": "typedoc && node scripts/postprocess-docs.js",
     "test": "npm run test --workspaces --if-present",
-    "build": "npm run build:libs && npm run docs && npm run build -w @ingglish/cors-proxy -w @ingglish/dom -w @ingglish/extension -w @ingglish/website",
-    "build:libs": "npm run build -w @ingglish/normalize -w @ingglish/phonemes && npm run build -w @ingglish/tokenize -w @ingglish/dictionary -w @ingglish/ipa && npm run build -w @ingglish/g2p -w @ingglish/shavian -w @ingglish/deseret && npm run build -w @ingglish/fallback && npm run build -w ingglish",
-    "build:fast": "npm run build:fast -w @ingglish/normalize -w @ingglish/phonemes && npm run build:fast -w @ingglish/tokenize -w @ingglish/dictionary -w @ingglish/ipa && npm run build:fast -w @ingglish/g2p -w @ingglish/shavian -w @ingglish/deseret && npm run build:fast -w @ingglish/fallback && npm run build:fast -w ingglish -w @ingglish/dom",
+    "build": "turbo build && npm run docs",
+    "build:fast": "turbo build:fast",
     "lint": "npm run lint --workspaces",
     "lint:fix": "npm run lint --workspaces -- --fix",
     "format": "prettier --write \"packages/*/src/**/*.{ts,tsx,js,jsx,json,css}\" \"**/package.json\" \"!node_modules\"",
@@ -69,6 +69,7 @@
     "stylelint": "^17.3.0",
     "stylelint-config-standard": "^40.0.0",
     "tsup": "^8.4.0",
+    "turbo": "^2.8.10",
     "typedoc": "^0.28.15",
     "typedoc-plugin-markdown": "^4.9.0",
     "typescript": "^5.8.3",

--- a/packages/cors-proxy/package.json
+++ b/packages/cors-proxy/package.json
@@ -6,6 +6,7 @@
   "type": "module",
   "scripts": {
     "build": "tsc --noEmit",
+    "build:fast": "tsc --noEmit",
     "lint": "eslint --cache src",
     "dev": "wrangler dev",
     "deploy": "wrangler deploy",

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -6,6 +6,7 @@
   "type": "module",
   "scripts": {
     "build": "tsup",
+    "build:fast": "tsup",
     "postbuild": "node scripts/copy-assets.js && node scripts/generate-icons.js",
     "build:icons": "node scripts/generate-icons.js",
     "test": "vitest run --no-color",

--- a/turbo.json
+++ b/turbo.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "tasks": {
+    "build": {
+      "dependsOn": ["^build"],
+      "outputs": ["dist/**"]
+    },
+    "build:fast": {
+      "dependsOn": ["^build:fast"],
+      "outputs": ["dist/**"]
+    },
+    "lint": {},
+    "test": {}
+  }
+}


### PR DESCRIPTION
## Summary
- Adds Turborepo to replace manual dependency-ordered `&&` chains in build scripts
- Turbo reads the package dependency graph and handles ordering + parallelism automatically
- Simplifies CI build job from 3 steps to 2

## Test plan
- [x] `npm run build:fast` builds all 14 packages with correct ordering
- [x] Second run hits full cache (408ms)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)